### PR TITLE
fix: Don't spam True when removing Type Accelerators

### DIFF
--- a/Modules/PSStyle/src/PSStyle.psm1
+++ b/Modules/PSStyle/src/PSStyle.psm1
@@ -42,7 +42,7 @@ foreach ($Type in $ExportableTypes) {
 # Remove type accelerators when the module is removed.
 $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
     foreach($Type in $ExportableTypes) {
-        $TypeAcceleratorsClass::Remove($Type.FullName)
+        $null = $TypeAcceleratorsClass::Remove($Type.FullName)
     }
 }.GetNewClosure()
 


### PR DESCRIPTION
Previously when removing the module there would be a True value output for each removed type, this prevents these from being output.