### PR TITLE
fix: Don't export unless required

### DIFF
--- a/Modules/PSStyle/src/PSStyle.psm1
+++ b/Modules/PSStyle/src/PSStyle.psm1
@@ -46,4 +46,6 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
     }
 }.GetNewClosure()
 
-Export-ModuleMember -Variable PSStyle
+if (-not ($PSVersionTable.PSVersion.Major -ge 7 -and $PSVersionTable.PSVersion.Minor -ge 2)) {
+    Export-ModuleMember -Variable PSStyle
+}


### PR DESCRIPTION
Puts the export behind a gate to prevent errors about $PSStyle being readonly.

When loading a module that imports psstyle there is no error printed but if importing directly in a session you would receive an error stating the $PSStyle was read-only.

Tested in 7.5 & 5.1.